### PR TITLE
update `augur export` syntax

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -187,7 +187,7 @@ rule traits:
         """
 
 rule export:
-    message: "Exporting data files for for auspice"
+    message: "Exporting data files for for auspice using V1 JSON schema"
     input:
         tree = rules.refine.output.tree,
         metadata = rules.add_authors.output.metadata,
@@ -203,7 +203,7 @@ rule export:
         auspice_meta = rules.all.input.auspice_meta
     shell:
         """
-        augur export \
+        augur export v1\
             --tree {input.tree} \
             --metadata {input.metadata} \
             --node-data {input.branch_lengths} {input.traits} {input.nt_muts} {input.aa_muts} \
@@ -212,11 +212,10 @@ rule export:
             --lat-longs {input.lat_longs} \
             --output-tree {output.auspice_tree} \
             --output-meta {output.auspice_meta}
-        #augur validate --json {output.auspice_meta} {output.auspice_tree}
         """
 
-rule export2:
-    message: "Exporting v2.0 JSONs for auspice. Currently unused."
+rule export_v2:
+    message: "Exporting data files for for auspice using V2 JSON schema"
     input:
         tree = rules.refine.output.tree,
         metadata = rules.add_authors.output.metadata,
@@ -226,21 +225,19 @@ rule export2:
         aa_muts = rules.translate.output.node_data,
         colors = rules.create_colors.output.colors,
         lat_longs = rules.create_lat_longs.output.lat_longs,
-        auspice_config = files.auspice_config
+        auspice_config = "config/auspice_config_v2.json"
     output:
         auspice = "auspice/WNV-nextstrain_NA.json"
     shell:
         """
-        augur export \
-            --new-schema \
+        augur export v2 \
             --tree {input.tree} \
             --metadata {input.metadata} \
             --node-data {input.branch_lengths} {input.traits} {input.nt_muts} {input.aa_muts} \
             --colors {input.colors} \
             --auspice-config {input.auspice_config} \
             --lat-longs {input.lat_longs} \
-            --output-main {output.auspice}
-        #augur validate --json {output.auspice_meta} {output.auspice_tree}
+            --output {output.auspice}
         """
 
 rule clean:

--- a/config/auspice_config_v2.json
+++ b/config/auspice_config_v2.json
@@ -1,0 +1,33 @@
+{
+  "title": "Twenty years of West Nile Virus in the Americas",
+  "colorings": [
+    {"key": "gt", "title": "Genotype", "type": "categorical"},
+    {"key": "num_date", "title": "Sampling Date", "type": "continuous"},
+    {"key": "country", "title": "Country", "type": "categorical"},
+    {"key": "state", "title": "State", "type": "categorical"},
+    {"key": "division", "title": "Division", "type": "categorical"},
+    {"key": "lineage", "title": "Strain", "type": "categorical"},
+    {"key": "author", "title": "Authors", "type": "categorical"},
+    {"key": "host", "title": "Host Species", "type": "categorical"}
+  ],
+  "geo_resolutions": [
+    "state",
+    "division"
+  ],
+  "maintainers": [
+    {"name": "Anderson Brito", "url": "http://grubaughlab.com/team/anderson-brito/"},
+    {"name": "James Hadfield", "url": "https://twitter.com/hamesjadfield"},
+    {"name": "Grubaugh Lab", "url": "http://grubaughlab.com/"}
+  ],
+  "filters": [
+    "country",
+    "state",
+    "authors",
+    "lineage"
+  ],
+  "display_defaults": {
+    "color_by": "state",
+    "map_triplicate": false,
+    "geo_resolution": "state"
+ }
+}


### PR DESCRIPTION
@andersonbrito we're in the process of releasing augur v6 which requires a few (small) changes to the way augur is called. 

This commit moves to the newer `augur export v1` syntax. This requires augur >=5.4.0. Let me know what augur version you're using (`augur --version`) and I can help you upgrade if needed (perhaps over slack).
> Note that augur ~5.4 will work both with the current master branch & this PR.

Additionally, this PR adds the augur-v6-only `export v2` command is added to the snakemake file (and corresponding config file added), but will not be run unless specifically requested. This will make it easy to switch to this once augur v6 is being used.